### PR TITLE
HP-2315 disabled logging in PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
             "constants": "config/constants.php",
             "params": "config/params.php",
             "common": "config/common.php",
-            "tests": "$common",
+            "tests": "config/tests.php",
             "console": [
                 "$common",
                 "config/console.php"

--- a/config/tests.php
+++ b/config/tests.php
@@ -1,0 +1,13 @@
+<?php
+
+use hiqdev\yii\compat\yii;
+use hiqdev\yii\compat\Buildtime;
+
+$config = require 'common.php';
+
+$logComponent = Buildtime::run(yii::is3()) ? 'logger' : 'log';
+
+// Disable logging
+$config['components'][$logComponent] = [];
+
+return $config;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated test configuration path in `composer.json`
	- Added new `tests.php` configuration file for test environment settings
	- Modified logging component configuration for testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->