### PR TITLE
HP-2434 Fix failing phpunit-legacy HiApi CI job due to "Class name must be a valid object or a string" error

### DIFF
--- a/src/Endpoint/EndpointProcessor.php
+++ b/src/Endpoint/EndpointProcessor.php
@@ -19,18 +19,16 @@ use yii\web\User;
 
 class EndpointProcessor
 {
-    /**
-     * @var Endpoint
-     */
-    private $endpoint;
-    /**
-     * @var ContainerInterface
-     */
-    private $di;
+    private Endpoint $endpoint;
 
-    public function __construct(ContainerInterface $di)
+    private ContainerInterface $di;
+
+    private User $user;
+
+    public function __construct(ContainerInterface $di, User $user)
     {
         $this->di = $di;
+        $this->user = $user;
     }
 
     /**
@@ -44,7 +42,7 @@ class EndpointProcessor
 
         $middlewares = [];
         $middlewares[] = new TypeCheckMiddleware($endpoint);
-        $middlewares[] = new CheckPermissionsMiddleware($endpoint, $this->di->get(User::class));
+        $middlewares[] = new CheckPermissionsMiddleware($endpoint, $this->user);
         $middlewares[] = $this->di->get(FixCustomerIdSpecification::class);
         $middlewares[] = new ValidateCommandMiddleware();
         $middlewares = array_merge($middlewares, $this->endpointMiddlewares());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of user information for endpoint processing. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->