### PR TITLE
HQD-182: Fix fatal error in hiqdev/hiapi caused by yiisoft/router v4 removing `Route::anyMethod()`

### DIFF
--- a/src/Http/EndpointRoute.php
+++ b/src/Http/EndpointRoute.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace hiapi\Core\Http;
 
 use Closure;
+use Yiisoft\Http\Method;
 use hiapi\Core\Http\Psr15\Middleware\EndpointMiddleware;
 use Yiisoft\Router\Route;
 
@@ -46,7 +47,7 @@ class EndpointRoute
 
     public static function anyMethod(string $pattern, string $name): Route
     {
-        return Route::anyMethod($pattern)->action(static::buildMiddlewareFor($name));
+        return Route::methods(Method::ALL, $pattern)->action(static::buildMiddlewareFor($name));
     }
 
     public static function buildMiddlewareFor(string $name): Closure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal route registration mechanism to use standardized HTTP method handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hiapi/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->